### PR TITLE
fix: drc labels

### DIFF
--- a/pkg/controller/distributedrediscluster/helper.go
+++ b/pkg/controller/distributedrediscluster/helper.go
@@ -25,7 +25,7 @@ func getLabels(cluster *redisv1alpha1.DistributedRedisCluster) map[string]string
 	dynLabels := map[string]string{
 		redisv1alpha1.LabelClusterName: cluster.Name,
 	}
-	return utils.MergeLabels(defaultLabels, dynLabels, cluster.Labels)
+	return utils.MergeLabels(defaultLabels, dynLabels)
 }
 
 // newRedisAdmin builds and returns new redis.Admin from the list of pods

--- a/pkg/controller/distributedrediscluster/helper.go
+++ b/pkg/controller/distributedrediscluster/helper.go
@@ -25,7 +25,7 @@ func getLabels(cluster *redisv1alpha1.DistributedRedisCluster) map[string]string
 	dynLabels := map[string]string{
 		redisv1alpha1.LabelClusterName: cluster.Name,
 	}
-	return utils.MergeLabels(defaultLabels, dynLabels)
+	return utils.MergeLabels(defaultLabels, dynLabels, cluster.Labels)
 }
 
 // newRedisAdmin builds and returns new redis.Admin from the list of pods


### PR DESCRIPTION
Currently, the operator retrieves its pods by searching for labels:

```go
func getLabels(cluster *redisv1alpha1.DistributedRedisCluster) map[string]string {
	dynLabels := map[string]string{
		redisv1alpha1.LabelClusterName: cluster.Name,
	}
	return utils.MergeLabels(defaultLabels, dynLabels, cluster.Labels)
}
```

While DRC labels are usually empty, in our case, Flux adds additional labels:

```yaml
labels:
  fluxcd.io/sync-gc-mark: sha256.nhrxx215wgg8L5dvy_kutX6h-Oqb9qRq1jVKyR0Ziw8
```
Since we cannot control the labels added by external systems, we shouldn't rely on DRC labels.